### PR TITLE
introducing OctaneManagerInitializer to allow starting plugin in the same way in all modes (console app or server plugin)

### DIFF
--- a/OctaneManager/Configuration/ConfigurationManager.cs
+++ b/OctaneManager/Configuration/ConfigurationManager.cs
@@ -1,4 +1,5 @@
 ﻿using log4net;
+using MicroFocus.Ci.Tfs.Octane.Tools;
 using System;
 using System.IO;
 using System.Reflection;
@@ -67,10 +68,8 @@ namespace MicroFocus.Ci.Tfs.Octane.Configuration
 			var configText = JsonHelper.SerializeObject(config, true);
 
 			Log.Info($"Writing configuration : {configText}");
-			_watcher.EnableRaisingEvents = false;
 			File.WriteAllText(configFile, configText);
-			_watcher.EnableRaisingEvents = true;
-			Log.Info("Done");
+			Log.Info($"Writing configuration done");
 		}
 
 		private static void CreateConfigDirIfMissing()

--- a/OctaneManager/OctaneManager.cs
+++ b/OctaneManager/OctaneManager.cs
@@ -175,12 +175,12 @@ namespace MicroFocus.Ci.Tfs.Octane
 
 		private void OnConfigurationChanged(object sender, EventArgs e)
 		{
-			IsInitialized = false;
 			Init();
 		}
 
 		public void Init()
 		{
+			IsInitialized = false;
 			_connectionConf = ConfigurationManager.Read();
 
 			var hostName = Dns.GetHostName();
@@ -197,8 +197,11 @@ namespace MicroFocus.Ci.Tfs.Octane
 
 			try
 			{
+				DateTime start = DateTime.Now;
 				Log.Debug($"Validate connection to TFS  {_tfsServerUri.ToString()}");
 				//_tfsManager.GetProjectCollections();
+				DateTime end = DateTime.Now;
+				Log.Debug($"Validate connection to TFS finished in {(long)((end-start).TotalMilliseconds)} ms");
 			}
 			catch (Exception e)
 			{
@@ -209,8 +212,11 @@ namespace MicroFocus.Ci.Tfs.Octane
 
 			try
 			{
+				DateTime start = DateTime.Now;
 				Log.Debug($"Validate connection to Octane {_connectionConf.Host}");
 				var octaneConnected = _octaneRestConnector.Connect(_connectionConf.Host, new APIKeyConnectionInfo(_connectionConf.ClientId, _connectionConf.ClientSecret));
+				DateTime end = DateTime.Now;
+				Log.Debug($"Validate connection to Octane finished in {(long)((end - start).TotalMilliseconds)} ms");
 			}
 			catch (Exception e)
 			{

--- a/OctaneManager/OctaneManager.csproj
+++ b/OctaneManager/OctaneManager.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Dto\Scm\ScmData.cs" />
     <Compile Include="Dto\Scm\ScmRepository.cs" />
     <Compile Include="Dto\Events\CiBuildResult.cs" />
+    <Compile Include="OctaneManagerInitializer.cs" />
     <Compile Include="Tools\JsonHelper.cs" />
     <Compile Include="OctaneManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/OctaneManager/OctaneManagerInitializer.cs
+++ b/OctaneManager/OctaneManagerInitializer.cs
@@ -1,0 +1,106 @@
+﻿using log4net;
+using MicroFocus.Ci.Tfs.Octane.Tools;
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MicroFocus.Ci.Tfs.Octane
+{
+	public class OctaneManagerInitializer : IDisposable
+	{
+		private static readonly TimeSpan _initTimeout = new TimeSpan(0, 0, 0, 10);
+		private OctaneManager _octaneManager = null;
+		private Task _octaneInitializationThread = null;
+		private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+		protected static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+		private PluginRunMode _runMode;
+
+		public void Start(PluginRunMode runMode)
+		{
+			if (_cancellationTokenSource.IsCancellationRequested)
+			{
+				throw new InvalidOperationException("You cannot use the same initializer after it stopped");
+			}
+
+			this._runMode = runMode;
+			Log.Info("OctaneManagerInitializer start");
+
+			Octane.RestServer.Server.GetInstance().Start();
+			if (_octaneInitializationThread == null)
+			{
+				_octaneInitializationThread =
+					Task.Factory.StartNew(() => InitializeOctaneManager(_cancellationTokenSource.Token),
+						TaskCreationOptions.LongRunning);
+			}
+		}
+
+		public OctaneManager OctaneManager
+		{
+			get
+			{
+				return _octaneManager;
+			}
+		}
+
+		public void ShutDown()
+		{
+			_cancellationTokenSource.Cancel();
+			_octaneManager.ShutDown();
+			RestServer.Server.GetInstance().Stop();
+		}
+
+		public void WaitShutDown()
+		{
+			if (_octaneManager != null)
+			{
+				_octaneManager.WaitShutdown();
+			}
+		}
+
+		private void InitializeOctaneManager(CancellationToken token)
+		{
+			while (!IsOctaneInitialized())
+			{
+				if (token.IsCancellationRequested)
+				{
+					Log.Info("Octane initialization thread was requested to quit!");
+					break;
+				}
+				try
+				{
+					if (_octaneManager == null)
+					{
+						_octaneManager = new OctaneManager(_runMode);
+					}
+
+					_octaneManager.Init();
+
+				}
+				catch (Exception ex)
+				{
+					Log.Error($"Error initializing octane plugin : {ex.Message}", ex);
+				}
+
+				//Sleep till next retry
+				if (!IsOctaneInitialized())
+				{
+					Log.Info($"Wait {_initTimeout.TotalSeconds} secs for next trial of initialization");
+				}
+				
+				Thread.Sleep(_initTimeout);
+
+			}
+		}
+
+		public bool IsOctaneInitialized()
+		{
+			return _octaneManager != null && _octaneManager.IsInitialized;
+		}
+
+		public void Dispose()
+		{
+			ShutDown();
+		}
+	}
+}

--- a/OctaneManager/RestServer/RestBase.cs
+++ b/OctaneManager/RestServer/RestBase.cs
@@ -1,6 +1,7 @@
 ﻿using log4net;
 using MicroFocus.Ci.Tfs.Octane.Dto;
 using MicroFocus.Ci.Tfs.Octane.Tfs.Beans.Events;
+using MicroFocus.Ci.Tfs.Octane.Tools;
 using Nancy;
 using Nancy.Extensions;
 using System;

--- a/OctaneManager/Tfs/Beans/Events/TfsBuildEvent.cs
+++ b/OctaneManager/Tfs/Beans/Events/TfsBuildEvent.cs
@@ -1,7 +1,7 @@
-﻿using MicroFocus.Ci.Tfs.Octane.dto.pipelines;
-using MicroFocus.Ci.Tfs.Octane.Dto;
+﻿using MicroFocus.Ci.Tfs.Octane.Dto;
 using MicroFocus.Ci.Tfs.Octane.Dto.Events;
 using MicroFocus.Ci.Tfs.Octane.Tfs.Beans.v1;
+using MicroFocus.Ci.Tfs.Octane.Tools;
 using System;
 using System.Linq;
 

--- a/OctaneManager/Tfs/Beans/v1/Subscriptions/SubscriptionRequest.cs
+++ b/OctaneManager/Tfs/Beans/v1/Subscriptions/SubscriptionRequest.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using MicroFocus.Ci.Tfs.Octane.Tools;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 

--- a/OctaneManager/Tools/JsonHelper.cs
+++ b/OctaneManager/Tools/JsonHelper.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace MicroFocus.Ci.Tfs.Octane
+namespace MicroFocus.Ci.Tfs.Octane.Tools
 {
 	public static class JsonHelper
 	{

--- a/OctaneManager/Tools/TaskProcessor.cs
+++ b/OctaneManager/Tools/TaskProcessor.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Web;
 
-namespace MicroFocus.Ci.Tfs.Octane
+namespace MicroFocus.Ci.Tfs.Octane.Tools
 {
 	internal class TaskProcessor
 	{

--- a/OctaneManager/Tools/TestResultUtils.cs
+++ b/OctaneManager/Tools/TestResultUtils.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace MicroFocus.Ci.Tfs.Octane
+namespace MicroFocus.Ci.Tfs.Octane.Tools
 {
 	public static class TestResultUtils
 	{

--- a/OctaneManager/Tools/TfsManager.cs
+++ b/OctaneManager/Tools/TfsManager.cs
@@ -12,7 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace MicroFocus.Ci.Tfs.Octane
+namespace MicroFocus.Ci.Tfs.Octane.Tools
 {
 	public class TfsManager
 	{

--- a/OctaneManager/Tools/ToStringJsonConverter.cs
+++ b/OctaneManager/Tools/ToStringJsonConverter.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MicroFocus.Ci.Tfs.Octane.Tools

--- a/OctaneManager/dto/Connectivity/OctaneTaskBase.cs
+++ b/OctaneManager/dto/Connectivity/OctaneTaskBase.cs
@@ -1,4 +1,5 @@
 ﻿using MicroFocus.Ci.Tfs.Octane.dto;
+using MicroFocus.Ci.Tfs.Octane.Tools;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/OctaneManager/dto/General/TfsCiEntity.cs
+++ b/OctaneManager/dto/General/TfsCiEntity.cs
@@ -1,4 +1,6 @@
-﻿namespace MicroFocus.Ci.Tfs.Octane.Dto.General
+﻿using MicroFocus.Ci.Tfs.Octane.Tools;
+
+namespace MicroFocus.Ci.Tfs.Octane.Dto.General
 {
 	public class TfsCiEntity
     {

--- a/OctaneTFSPlugin/CiEventUtils.cs
+++ b/OctaneTFSPlugin/CiEventUtils.cs
@@ -1,6 +1,6 @@
-﻿using MicroFocus.Ci.Tfs.Octane;
-using MicroFocus.Ci.Tfs.Octane.Dto;
+﻿using MicroFocus.Ci.Tfs.Octane.Dto;
 using MicroFocus.Ci.Tfs.Octane.Dto.Events;
+using MicroFocus.Ci.Tfs.Octane.Tools;
 using Microsoft.TeamFoundation.Build.WebApi;
 using System.Linq;
 

--- a/OctaneTFSPluginTests/OctaneManagerBaseTest.cs
+++ b/OctaneTFSPluginTests/OctaneManagerBaseTest.cs
@@ -1,5 +1,6 @@
 ﻿using MicroFocus.Ci.Tfs.Octane;
 using MicroFocus.Ci.Tfs.Octane.Configuration;
+using MicroFocus.Ci.Tfs.Octane.Tools;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using SystemConfigurationManager = System.Configuration.ConfigurationManager;

--- a/TfsConsolePluginRunner/Program.cs
+++ b/TfsConsolePluginRunner/Program.cs
@@ -5,6 +5,7 @@ using log4net.Config;
 using MicroFocus.Ci.Tfs.Octane;
 using MicroFocus.Ci.Tfs.Octane.Configuration;
 using MicroFocus.Ci.Tfs.Octane.Tools;
+using System.Threading;
 
 [assembly: XmlConfigurator(ConfigFile = @"agent-log-config.xml", Watch = true)]
 namespace TfsConsolePluginRunner
@@ -22,16 +23,15 @@ namespace TfsConsolePluginRunner
                 ConfigurationManager.WriteConfig(ConfigFileGenerator.GenerateConfig());
             }
 
-			MicroFocus.Ci.Tfs.Octane.RestServer.Server.GetInstance().Start();
-			var _octaneManager = new OctaneManager(PluginRunMode.ConsoleApp);
-            _octaneManager.Init();
-
-            Console.WriteLine("TFS plugin is running , press any key to exit...");
+			OctaneManagerInitializer octaneManagerInitializer = new OctaneManagerInitializer();
+			octaneManagerInitializer.Start(PluginRunMode.ConsoleApp);
+			Console.WriteLine("TFS plugin is running , press any key to exit...");
             Console.ReadLine();
 
-			MicroFocus.Ci.Tfs.Octane.RestServer.Server.GetInstance().Stop();
-			_octaneManager.ShutDown();
-            _octaneManager.WaitShutdown();
-        }
+			octaneManagerInitializer.ShutDown();
+			octaneManagerInitializer.WaitShutDown();
+			Console.WriteLine("TFS plugin is stopped. The window will close shortly.");
+			Thread.Sleep(5000);
+		}
     }
 }


### PR DESCRIPTION
OctaneManagerInitializer shouldallow starting plugin in the same way in all modes (console app or server plugin)